### PR TITLE
MINT-5092 Remove reference to gcc-8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN mkdir /.aptible/
 COPY Procfile /.aptible/
 
 FROM ${BUILD_IMAGE}-version AS final_image
-RUN apt-get remove -y gcc gcc-8
+RUN apt-get remove -y gcc
 
 COPY ./app /app
 COPY ./newrelic.ini /app/newrelic.ini


### PR DESCRIPTION
Due to updates in the underlying docker images, gcc-8 is no longer present in the image at this step.  Removing this reference to remove any warnings/errors raised to users. 

Closes #1 