### PR TITLE
MINT-5092 Shifting from 'health' to 'healthcheck' per org standard.

### DIFF
--- a/app/app/main.py
+++ b/app/app/main.py
@@ -52,7 +52,7 @@ app.add_middleware(RequestTimingMiddleware)
 if settings.ENABLE_RATE_LIMITING:  # pragma: no cover
     app.add_middleware(SlowAPIMiddleware)
     app.add_exception_handler(RateLimitExceeded, rate_limiter_exception_handler)
-app.add_api_route("/health", rate_limiter.exempt(route.health(checks)))
+app.add_api_route("/healthcheck", rate_limiter.exempt(route.health(checks)))
 app.add_api_route("/version", version.endpoint)
 
 

--- a/app/app/tests/unit/core/test_health_routes.py
+++ b/app/app/tests/unit/core/test_health_routes.py
@@ -34,7 +34,7 @@ def sick():
 )
 def test_health(conditions, status_code):
     app = FastAPI()
-    app.add_api_route("/health", health(conditions))
+    app.add_api_route("/healthcheck", health(conditions))
     with TestClient(app) as client:
-        res = client.get("/health")
+        res = client.get("/healthcheck")
         assert res.status_code == status_code


### PR DESCRIPTION
Applications at HingeHealth standardized on the endpoint of `/healthcheck` for health checks.  This integrates that standard into the template service.

Closes #2 