### PR TITLE
ELIG-413 Remove continue-on-error from unit tests

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -67,7 +67,6 @@ jobs:
           ENVIRONMENT: test
           COVERAGE_FILE: .coverage.unit
         run: poetry run pytest -m unit
-        continue-on-error: true
       - name: Store coverage report
         if: always()
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
https://hingehealth.atlassian.net/browse/ELIG-413

### Purpose
Removing line because it causes job to pass even when the tests fail